### PR TITLE
Various fixes

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,3 +1,3 @@
 1. Update `nimv.nuspec` with changes, and version number
 2. `choco pack`
-3. `choco push nimv.0.0.4.nupkg --source=https://push.chocolatey.org --key=<API_KEY>`
+3. `choco push nimv.0.0.8.nupkg --source=https://push.chocolatey.org --key=<API_KEY>`

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,13 +1,25 @@
 $ErrorActionPreference = 'Stop'
-
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $sourceFile = Join-Path $toolsDir 'nimv.bat'
 $targetDir = "$($env:ChocolateyInstall)\bin"
 $targetFile = Join-Path $targetDir 'nimv.bat'
 $nixStyleTarget = Join-Path $targetDir 'nimv'
+try {
+    Write-Host "Installing nimv from $sourceFile to $targetFile"
+    if (!(Test-Path $targetDir)) {
+        New-Item -ItemType Directory -Path $targetDir -Force
+    }
+    # Install the batch file
+    Copy-Item -Path $sourceFile -Destination $targetFile -Force
+    # Create a shell script wrapper for MSYS2/Unix environments
+    $shellScript = @"
+#!/bin/sh
+exec nimv.bat `"`$@`"
+"@
+    $shellScript | Out-File -FilePath $nixStyleTarget -Encoding ASCII -NoNewline
+    Write-Host "Nimv has been installed successfully to: $targetFile"
 
-# Function to add Nimble to PATH
-function Add-NimbleToPath {
+    # Add Nimble to PATH configuration (PowerShell only)
     $NimbleBinPath = "$env:USERPROFILE\.nimble\bin"
 
     # Create the nimble bin directory if it doesn't exist
@@ -16,108 +28,36 @@ function Add-NimbleToPath {
         Write-Host "Created Nimble bin directory: $NimbleBinPath"
     }
 
-    # Detect environment: PowerShell, CMD, or MSYS2
-    $envType = "PowerShell"
-
-    # Check if we're in MSYS2
-    if ($env:MSYSTEM) {
-        $envType = "MSYS2"
-    }
-    # Check if we're in cmd.exe (less reliable check)
-    elseif ($Host.Name -eq "ConsoleHost" -and $PSVersionTable.PSEdition -eq $null) {
-        $envType = "CMD"
+    # Modify user PATH environment variable
+    $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    if ($currentPath -notmatch [regex]::Escape($NimbleBinPath)) {
+        [Environment]::SetEnvironmentVariable("PATH", "$NimbleBinPath;$currentPath", "User")
+        Write-Host "Added Nimble to User PATH environment variable"
+    } else {
+        Write-Host "Nimble PATH already configured in User environment variables"
     }
 
-    switch ($envType) {
-        "PowerShell" {
-            # Check if PowerShell profile exists, create if not
-            if (-not (Test-Path $PROFILE)) {
-                New-Item -Type File -Path $PROFILE -Force | Out-Null
-                Write-Host "Created PowerShell profile: $PROFILE"
-            }
-
-            # Check if path is already in profile
-            $profileContent = Get-Content $PROFILE -ErrorAction SilentlyContinue
-            if ($profileContent -notmatch [regex]::Escape($NimbleBinPath)) {
-                Add-Content -Path $PROFILE -Value "`n# Add Nimble to PATH`n`$env:PATH = `"$NimbleBinPath;`$env:PATH`""
-                Write-Host "Added Nimble to PATH in PowerShell profile: $PROFILE"
-            } else {
-                Write-Host "Nimble PATH already configured in PowerShell profile"
-            }
-
-            $configFile = $PROFILE
-            $activateCmd = ". $PROFILE"
+    # PowerShell profile configuration
+    if (-not (Test-Path $PROFILE)) {
+        $profileDir = Split-Path -Parent $PROFILE
+        if (-not (Test-Path $profileDir)) {
+            New-Item -Type Directory -Path $profileDir -Force | Out-Null
         }
-
-        "CMD" {
-            # For CMD, we'll modify the user environment variable directly
-            $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-            if ($currentPath -notmatch [regex]::Escape($NimbleBinPath)) {
-                [Environment]::SetEnvironmentVariable("PATH", "$NimbleBinPath;$currentPath", "User")
-                Write-Host "Added Nimble to User PATH environment variable"
-            } else {
-                Write-Host "Nimble PATH already configured in User environment variables"
-            }
-
-            $configFile = "User Environment Variables"
-            $activateCmd = "Please restart your Command Prompt"
-        }
-
-        "MSYS2" {
-            # For MSYS2, add to .bash_profile
-            $bashProfile = "$env:USERPROFILE\.bash_profile"
-            if (-not (Test-Path $bashProfile)) {
-                New-Item -Type File -Path $bashProfile -Force | Out-Null
-                Write-Host "Created bash profile: $bashProfile"
-            }
-
-            $profileContent = Get-Content $bashProfile -ErrorAction SilentlyContinue
-            if ($profileContent -notmatch [regex]::Escape($NimbleBinPath)) {
-                # Convert Windows path to Unix-style path for MSYS2
-                $unixPath = $NimbleBinPath -replace '\\', '/' -replace '^(\w):', '/\L$1'
-                Add-Content -Path $bashProfile -Value "`n# Add Nimble to PATH`nexport PATH=`"$unixPath:`$PATH`""
-                Write-Host "Added Nimble to PATH in bash profile: $bashProfile"
-            } else {
-                Write-Host "Nimble PATH already configured in bash profile"
-            }
-
-            $configFile = $bashProfile
-            $activateCmd = "source $bashProfile"
-        }
+        New-Item -Type File -Path $PROFILE -Force | Out-Null
+        Write-Host "Created PowerShell profile: $PROFILE"
     }
 
-    Write-Host "----------------------------------------------------------------"
-    Write-Host "Nimble bin directory ($NimbleBinPath) has been created and"
-    Write-Host "added to PATH in your environment configuration."
-    Write-Host ""
-    Write-Host "To activate this change in your current session, run:"
-    Write-Host "    $activateCmd"
-    Write-Host ""
-    Write-Host "Alternatively, you can start a new terminal session."
-    Write-Host "----------------------------------------------------------------"
-}
-
-try {
-    Write-Host "Installing nimv from $sourceFile to $targetFile"
-
-    if (!(Test-Path $targetDir)) {
-        New-Item -ItemType Directory -Path $targetDir -Force
+    $profileContent = Get-Content $PROFILE -ErrorAction SilentlyContinue
+    if ($profileContent -notmatch [regex]::Escape($NimbleBinPath)) {
+        Add-Content -Path $PROFILE -Value "`n# Add Nimble to PATH`n`$env:PATH = `"$NimbleBinPath;`$env:PATH`""
+        Write-Host "Added Nimble to PATH in PowerShell profile: $PROFILE"
+    } else {
+        Write-Host "Nimble PATH already configured in PowerShell profile"
     }
 
-    # Install the batch file
-    Copy-Item -Path $sourceFile -Destination $targetFile -Force
+    # Simple completion message without detailed instructions
+    Write-Host "Nimble bin directory ($NimbleBinPath) has been created and added to PATH"
 
-    # Create a shell script wrapper for MSYS2/Unix environments
-    $shellScript = @"
-#!/bin/sh
-exec nimv.bat `"`$@`"
-"@
-
-    $shellScript | Out-File -FilePath $nixStyleTarget -Encoding ASCII -NoNewline
-
-    Add-NimbleToPath
-
-    Write-Host "Nimv has been installed successfully to: $targetFile"
 } catch {
     Write-Host "An error occurred during installation:"
     Write-Host $_

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -6,6 +6,97 @@ $targetDir = "$($env:ChocolateyInstall)\bin"
 $targetFile = Join-Path $targetDir 'nimv.bat'
 $nixStyleTarget = Join-Path $targetDir 'nimv'
 
+# Function to add Nimble to PATH
+function Add-NimbleToPath {
+    $NimbleBinPath = "$env:USERPROFILE\.nimble\bin"
+
+    # Create the nimble bin directory if it doesn't exist
+    if (-not (Test-Path $NimbleBinPath)) {
+        New-Item -ItemType Directory -Path $NimbleBinPath -Force | Out-Null
+        Write-Host "Created Nimble bin directory: $NimbleBinPath"
+    }
+
+    # Detect environment: PowerShell, CMD, or MSYS2
+    $envType = "PowerShell"
+
+    # Check if we're in MSYS2
+    if ($env:MSYSTEM) {
+        $envType = "MSYS2"
+    }
+    # Check if we're in cmd.exe (less reliable check)
+    elseif ($Host.Name -eq "ConsoleHost" -and $PSVersionTable.PSEdition -eq $null) {
+        $envType = "CMD"
+    }
+
+    switch ($envType) {
+        "PowerShell" {
+            # Check if PowerShell profile exists, create if not
+            if (-not (Test-Path $PROFILE)) {
+                New-Item -Type File -Path $PROFILE -Force | Out-Null
+                Write-Host "Created PowerShell profile: $PROFILE"
+            }
+
+            # Check if path is already in profile
+            $profileContent = Get-Content $PROFILE -ErrorAction SilentlyContinue
+            if ($profileContent -notmatch [regex]::Escape($NimbleBinPath)) {
+                Add-Content -Path $PROFILE -Value "`n# Add Nimble to PATH`n`$env:PATH = `"$NimbleBinPath;`$env:PATH`""
+                Write-Host "Added Nimble to PATH in PowerShell profile: $PROFILE"
+            } else {
+                Write-Host "Nimble PATH already configured in PowerShell profile"
+            }
+
+            $configFile = $PROFILE
+            $activateCmd = ". $PROFILE"
+        }
+
+        "CMD" {
+            # For CMD, we'll modify the user environment variable directly
+            $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+            if ($currentPath -notmatch [regex]::Escape($NimbleBinPath)) {
+                [Environment]::SetEnvironmentVariable("PATH", "$NimbleBinPath;$currentPath", "User")
+                Write-Host "Added Nimble to User PATH environment variable"
+            } else {
+                Write-Host "Nimble PATH already configured in User environment variables"
+            }
+
+            $configFile = "User Environment Variables"
+            $activateCmd = "Please restart your Command Prompt"
+        }
+
+        "MSYS2" {
+            # For MSYS2, add to .bash_profile
+            $bashProfile = "$env:USERPROFILE\.bash_profile"
+            if (-not (Test-Path $bashProfile)) {
+                New-Item -Type File -Path $bashProfile -Force | Out-Null
+                Write-Host "Created bash profile: $bashProfile"
+            }
+
+            $profileContent = Get-Content $bashProfile -ErrorAction SilentlyContinue
+            if ($profileContent -notmatch [regex]::Escape($NimbleBinPath)) {
+                # Convert Windows path to Unix-style path for MSYS2
+                $unixPath = $NimbleBinPath -replace '\\', '/' -replace '^(\w):', '/\L$1'
+                Add-Content -Path $bashProfile -Value "`n# Add Nimble to PATH`nexport PATH=`"$unixPath:`$PATH`""
+                Write-Host "Added Nimble to PATH in bash profile: $bashProfile"
+            } else {
+                Write-Host "Nimble PATH already configured in bash profile"
+            }
+
+            $configFile = $bashProfile
+            $activateCmd = "source $bashProfile"
+        }
+    }
+
+    Write-Host "----------------------------------------------------------------"
+    Write-Host "Nimble bin directory ($NimbleBinPath) has been created and"
+    Write-Host "added to PATH in your environment configuration."
+    Write-Host ""
+    Write-Host "To activate this change in your current session, run:"
+    Write-Host "    $activateCmd"
+    Write-Host ""
+    Write-Host "Alternatively, you can start a new terminal session."
+    Write-Host "----------------------------------------------------------------"
+}
+
 try {
     Write-Host "Installing nimv from $sourceFile to $targetFile"
 
@@ -23,6 +114,8 @@ exec nimv.bat `"`$@`"
 "@
 
     $shellScript | Out-File -FilePath $nixStyleTarget -Encoding ASCII -NoNewline
+
+    Add-NimbleToPath
 
     Write-Host "Nimv has been installed successfully to: $targetFile"
 } catch {

--- a/tools/nimv.bat
+++ b/tools/nimv.bat
@@ -396,7 +396,9 @@ if exist "%NIM_BIN_PATH%\nim.exe" (
 
     echo Cleaning up installation directory...
     cd /d "%NIM_DIR%"
-    for /d %%i in (*) do if not "%%i"=="bin" rd /s /q "%%i"
+    set "exclude=|bin|lib|dist|config|compiler|"
+    for /d %%i in (*) do if "!exclude:|%%~i|=!" equ "%exclude%" rd /s /q "%%~i"
+    for /d %%i in (dist\*) do if not "%%i"=="dist\checksums" rd /s /q "%%i"
     for %%i in (*) do del /q "%%i"
 
     :: Remove nim_csources binary from bin

--- a/tools/nimv.bat
+++ b/tools/nimv.bat
@@ -275,6 +275,13 @@ exit /b 0
 set "has_error=false"
 
 :: Check nim binary
+for /f "tokens=*" %%v in ('bash -c "nimv current 2>/dev/null"') do set "current_version=%%v"
+if "%current_version%"=="No version currently selected" (
+    call :show_status "Checking nim binary platform matches current platform" "failure"
+    echo   Error: No nim version currently selected
+    set "has_error=true"
+)
+
 for /f "tokens=*" %%i in ('bash -c "which nim 2>/dev/null"') do set "nim_path=%%i"
 if "%nim_path%"=="" (
     call :show_status "Checking nim binary platform matches current platform" "failure"
@@ -287,7 +294,6 @@ if "%nim_path%"=="" (
 
 :: Check nim version matches
 for /f "tokens=*" %%v in ('bash -c "nim --version 2>/dev/null | head -n1 | sed 's/Nim Compiler Version \([0-9.]*\).*/\1/'"') do set "nim_version=%%v"
-for /f "tokens=*" %%v in ('bash -c "nimv current 2>/dev/null"') do set "current_version=%%v"
 
 if "%nim_version%"=="" (
     call :show_status "Checking nim binary version matches nim version selected with nimv" "failure"

--- a/tools/nimv.bat
+++ b/tools/nimv.bat
@@ -14,7 +14,7 @@ set "USER_HOME=%USERPROFILE%"
 
 :: Set up colors and symbols based on environment
 set "GREEN=[92m"
-set "RED=[91"
+set "RED=[91m"
 set "YELLOW=[93m"
 set "CYAN=[96m"
 set "NC=[0m"
@@ -276,14 +276,12 @@ set "has_error=false"
 
 :: Check nim binary
 for /f "tokens=*" %%v in ('bash -c "nimv current 2>/dev/null"') do set "current_version=%%v"
+for /f "tokens=*" %%i in ('bash -c "which nim 2>/dev/null"') do set "nim_path=%%i"
 if "%current_version%"=="No version currently selected" (
     call :show_status "Checking nim binary platform matches current platform" "failure"
     echo   Error: No nim version currently selected
     set "has_error=true"
-)
-
-for /f "tokens=*" %%i in ('bash -c "which nim 2>/dev/null"') do set "nim_path=%%i"
-if "%nim_path%"=="" (
+) else if "%nim_path%"=="" (
     call :show_status "Checking nim binary platform matches current platform" "failure"
     echo   Error: nim not found in PATH
     set "has_error=true"
@@ -295,7 +293,11 @@ if "%nim_path%"=="" (
 :: Check nim version matches
 for /f "tokens=*" %%v in ('bash -c "nim --version 2>/dev/null | head -n1 | sed 's/Nim Compiler Version \([0-9.]*\).*/\1/'"') do set "nim_version=%%v"
 
-if "%nim_version%"=="" (
+if "%current_version%"=="No version currently selected" (
+    call :show_status "Checking nim binary version matches nim version selected with nimv" "failure"
+    echo   Error: No nim version currently selected
+    set "has_error=true"
+) else if "%nim_version%"=="" (
     call :show_status "Checking nim binary version matches nim version selected with nimv" "failure"
     echo   Error: Could not determine Nim version
     set "has_error=true"

--- a/tools/nimv.bat
+++ b/tools/nimv.bat
@@ -106,47 +106,6 @@ for %%b in (nim.exe nim-gdb.exe nimble.exe nimgrep.exe nimpretty.exe nimsuggest.
     if exist "%nimble_dir%\%%b" del "%nimble_dir%\%%b"
     if exist "%bin_dir%\%%b" mklink "%nimble_dir%\%%b" "%bin_dir%\%%b"
 )
-
-:: Check if .nimble/bin is in PATH
-set "NIMBLE_BIN_PATH=%USER_HOME%\.nimble\bin"
-
-:: Detect environment
-set "IS_MSYS2="
-if defined MSYSTEM set "IS_MSYS2=1"
-
-:: Convert Windows path to Unix-style for MSYS2 if needed
-if defined IS_MSYS2 (
-    set "NIMBLE_BIN_PATH=%USER_HOME:\=/%/.nimble/bin"
-)
-
-:: Check PATH
-if defined IS_MSYS2 (
-    echo ";%PATH%;" | grep -q "%NIMBLE_BIN_PATH%"
-    if !ERRORLEVEL! neq 0 (
-        set "PATH=%NIMBLE_BIN_PATH%:!PATH!"
-        echo.
-        echo Note: %NIMBLE_BIN_PATH% has been added to PATH for this session
-        echo To add it permanently in MSYS2:
-        echo   1. Edit your shell configuration file ^(e.g., ~/.bashrc or ~/.bash_profile^)
-        echo   2. Add the line: export PATH=\"%NIMBLE_BIN_PATH%:\$PATH\"
-        echo   3. Restart your terminal or run: source ~/.bashrc
-    )
-) else (
-    echo ";%PATH%;" | findstr /I /C:"%NIMBLE_BIN_PATH%" >nul
-    if errorlevel 1 (
-        set "PATH=%NIMBLE_BIN_PATH%;%PATH%"
-        echo.
-        echo Note: %NIMBLE_BIN_PATH% has been added to PATH for this session
-        echo To add it permanently in Windows Command Prompt:
-        echo   1. Open System Properties ^(Windows + Pause/Break^)
-        echo   2. Click "Advanced system settings"
-        echo   3. Click "Environment Variables"
-        echo   4. Under "User variables for %USERNAME%", find "Path"
-        echo   5. Click "Edit" and add: %NIMBLE_BIN_PATH%
-        echo   6. Click OK on all windows
-        echo   7. Restart any open terminals
-    )
-)
 exit /b 0
 
 :available

--- a/tools/nimv.bat
+++ b/tools/nimv.bat
@@ -2,7 +2,7 @@
 setlocal EnableDelayedExpansion
 
 :: Script version and immediate command handling
-set "VERSION=0.0.4"
+set "VERSION=0.0.8"
 if "%~1"=="--version" (
     echo %VERSION%
     exit /b 0


### PR DESCRIPTION
- fix: less aggressive cleanup
- fix: `nimv check` works without having a nim version installed
- fix: `nimv check` error message red cross not showing correctly
- add post-install script that sets PATH correctly
- refactor: remove instructions after switching versions (no longer needed due to post-install script changes)